### PR TITLE
 Float stemcell every time we upload a product

### DIFF
--- a/apply-updates/pipeline.yml
+++ b/apply-updates/pipeline.yml
@@ -78,7 +78,7 @@ jobs:
             for stemcell in $(ls ${download_dir}/*.tgz); do
               echo "Uploading ${stemcell} to https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}"
               om \
-                upload-stemcell --stemcell "${stemcell}"
+                upload-stemcell --stemcell "${stemcell}" --floating "false"
             done
           }
 

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -205,7 +205,7 @@ jobs:
 
           chmod +x workspace/*
 
-          mv terraforming-azure workspace/terraforming-azure
+          cp -R terraforming-azure workspace/terraforming-azure
 
           cp pcf-pipelines/ci/Dockerfile workspace
 

--- a/operations/create-install-pcf-vsphere-offline-pipeline.yml
+++ b/operations/create-install-pcf-vsphere-offline-pipeline.yml
@@ -172,7 +172,8 @@
                   --password "$OPS_MGR_PASSWORD" \
                   --skip-ssl-validation \
                   upload-stemcell \
-                  --stemcell "./${stemcell_to_download}"
+                  --stemcell "./${stemcell_to_download}" \
+                  --floating "false"
               fi
             fi
 

--- a/tasks/restore-stemcells/task.sh
+++ b/tasks/restore-stemcells/task.sh
@@ -34,7 +34,8 @@ function main() {
         --username "${OPSMAN_USERNAME}" \
         --password "${OPSMAN_PASSWORD}" \
         upload-stemcell \
-        --stemcell "${stemcell}"
+        --stemcell "${stemcell}" \
+        --floating "false"
   done
 }
 

--- a/tasks/upload-product-and-stemcell/task.sh
+++ b/tasks/upload-product-and-stemcell/task.sh
@@ -74,6 +74,7 @@ if [ -n "$STEMCELL_VERSION" ]; then
       -p "$OPS_MGR_PWD" \
       -k \
       upload-stemcell \
+      --floating "false"
       -s $SC_FILE_PATH
   fi
 fi

--- a/tasks/upload-product-and-stemcell/task.sh
+++ b/tasks/upload-product-and-stemcell/task.sh
@@ -74,7 +74,7 @@ if [ -n "$STEMCELL_VERSION" ]; then
       -p "$OPS_MGR_PWD" \
       -k \
       upload-stemcell \
-      --floating "false"
+      --floating "false" \
       -s $SC_FILE_PATH
   fi
 fi


### PR DESCRIPTION
When setting up Harbor 1.6 after setting up PKS 1.2 (ubuntu-xenial 97.17), the PKS stemcell has become incompatible latest version. Set `--floating` flag to suppress this.